### PR TITLE
Add proxy and ecs cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,12 @@ prek (or pre-commit) will run some autoformatters, and TFlint.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_certificate"></a> [certificate](#module\_certificate) | ./certificate | n/a |
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | ./ecs-cluster | n/a |
 | <a name="module_dnsresolver"></a> [dnsresolver](#module\_dnsresolver) | ./dnsresolver | n/a |
 | <a name="module_efs"></a> [efs](#module\_efs) | ./efs | n/a |
 | <a name="module_k8tre-argocd-eks"></a> [k8tre-argocd-eks](#module\_k8tre-argocd-eks) | ./k8tre-eks | n/a |
 | <a name="module_k8tre-eks"></a> [k8tre-eks](#module\_k8tre-eks) | ./k8tre-eks | n/a |
+| <a name="module_squid"></a> [squid](#module\_squid) | ./proxy | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.6.0 |
 
 ### Inputs

--- a/ecs-cluster/main.tf
+++ b/ecs-cluster/main.tf
@@ -1,0 +1,96 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_kms_key" "ecs" {
+  description             = "${var.name} ECS Cluster KMS Key"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "ECS"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = format("arn:aws:iam::%s:root", data.aws_caller_identity.current.account_id)
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow CloudWatch Logs"
+        Effect = "Allow"
+        Principal = {
+          Service = "logs.${data.aws_region.current.region}.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ],
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = [
+              "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:${var.name}/*"
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "ecs" {
+  name          = "alias/${var.name}/ecs"
+  target_key_id = aws_kms_key.ecs.key_id
+}
+
+resource "aws_cloudwatch_log_group" "ecs-logs" {
+  name              = "${var.name}/ecs"
+  retention_in_days = 3653
+
+  kms_key_id = aws_kms_key.ecs.arn
+}
+
+# tfsec:ignore:aws-ecs-enable-container-insight
+resource "aws_ecs_cluster" "ecs" {
+  name = var.name
+
+  configuration {
+    execute_command_configuration {
+      kms_key_id = aws_kms_key.ecs.arn
+      logging    = "OVERRIDE"
+
+      log_configuration {
+        cloud_watch_encryption_enabled = true
+        cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs-logs.name
+      }
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "fargate" {
+  cluster_name = aws_ecs_cluster.ecs.name
+
+  capacity_providers = ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = "FARGATE"
+  }
+}
+
+# The service discovery namespace lives in the Route53 VPC, which
+# means the TRE's route53 resolver is able to see it and will respond
+# to queries for that zone.
+resource "aws_service_discovery_private_dns_namespace" "ecs" {
+  name        = var.discovery_domain
+  description = "Service Discovery namespace for ECS"
+  vpc         = var.vpc_r53_id
+}

--- a/ecs-cluster/main.tf
+++ b/ecs-cluster/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.14"
+    }
+  }
+
+  required_version = ">= 1.10.0"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/ecs-cluster/outputs.tf
+++ b/ecs-cluster/outputs.tf
@@ -1,0 +1,20 @@
+output "kms_id" {
+  value = aws_kms_key.ecs.id
+}
+
+output "kms_arn" {
+  value = aws_kms_key.ecs.arn
+}
+
+output "ecs_cluster" {
+  value = aws_ecs_cluster.ecs.name
+}
+
+output "discovery_id" {
+  value = aws_service_discovery_private_dns_namespace.ecs.id
+}
+
+output "kms_logs_arn" {
+  description = "KMS key that can be used for log groups {ecs_cluster}/*"
+  value       = aws_kms_key.ecs.arn
+}

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_r53_id" {
+  type = string
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "discovery_domain" {
+  type = string
+}

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -2,16 +2,8 @@ variable "name" {
   type = string
 }
 
-variable "vpc_id" {
-  type = string
-}
-
 variable "vpc_r53_id" {
   type = string
-}
-
-variable "subnets" {
-  type = list(string)
 }
 
 variable "discovery_domain" {

--- a/proxy/squid.tf
+++ b/proxy/squid.tf
@@ -1,0 +1,246 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_cloudwatch_log_group" "squid_proxy" {
+  name = "${var.ecs_cluster}/squid-proxy"
+
+  kms_key_id = var.kms_key
+}
+
+resource "aws_cloudwatch_log_metric_filter" "squid_proxy_denied" {
+  name    = "squid-proxy-denied"
+  pattern = "TCP_DENIED"
+
+  log_group_name = aws_cloudwatch_log_group.squid_proxy.name
+
+  metric_transformation {
+    name      = "SquidTcpDenied"
+    namespace = "ServiceAnomalies"
+    value     = "1"
+  }
+}
+
+# The threshold should ignore the health check, but any additional requests should trigger the alarm.
+resource "aws_cloudwatch_metric_alarm" "squid_tcp_denied" {
+  alarm_name                = "Squid proxy TCP_DENIED rate"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "SquidTcpDenied"
+  namespace                 = "ServiceAnomalies"
+  period                    = "30"
+  statistic                 = "Sum"
+  threshold                 = "4"
+  alarm_description         = "Squid proxy TCP_DENIED requests is higher than expected"
+  insufficient_data_actions = []
+  alarm_actions             = []
+  ok_actions                = []
+}
+
+resource "aws_iam_role_policy" "squid_proxy_exec" {
+  name = "execution-role"
+  role = aws_iam_role.squid_proxy_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = format("arn:aws:logs:%s:%s:log-group:%s:*", data.aws_region.current.region, data.aws_caller_identity.current.account_id, aws_cloudwatch_log_group.squid_proxy.name)
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "squid_proxy_exec" {
+  name = "squid-proxy-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "squid_proxy_task" {
+  name = "squid-proxy-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = format("arn:aws:ecs:%s:%s:*", data.aws_region.current.region, data.aws_caller_identity.current.account_id)
+          },
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ecs_task_definition" "squid_proxy" {
+  family       = "squid-proxy"
+  network_mode = "awsvpc"
+
+  requires_compatibilities = [
+    "FARGATE"
+  ]
+
+  cpu    = 256
+  memory = 512
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  task_role_arn      = aws_iam_role.squid_proxy_task.arn
+  execution_role_arn = aws_iam_role.squid_proxy_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "squid"
+      image = "${var.squid_proxy_repository}:${var.squid_proxy_version}"
+
+      essential = true
+      portMappings = [
+        {
+          containerPort = 3128
+          hostPort      = 3128
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.squid_proxy.name
+          awslogs-region        = data.aws_region.current.region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+      healthCheck = {
+        command = [
+          "CMD-SHELL",
+          "curl -k -x http://localhost:3128 http://localhost"
+        ]
+        interval    = 30
+        retries     = 3
+        startPeriod = 180
+        timeout     = 5
+      }
+      environment = [
+        {
+          name  = "ALLOWED_DOMAINS"
+          value = join(",", var.squid_proxy_allowed_domains)
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_security_group" "squid_proxy" {
+  name        = "ecs-squid-proxy"
+  description = "Security group for squid-proxy-container"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "squid-proxy"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "squid_proxy_local" {
+  security_group_id            = aws_security_group.squid_proxy.id
+  referenced_security_group_id = aws_security_group.squid_proxy.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "squid_proxy_tre" {
+  security_group_id = aws_security_group.squid_proxy.id
+  ip_protocol       = "tcp"
+  from_port         = 3128
+  to_port           = 3128
+  cidr_ipv4         = "10.0.0.0/8"
+}
+
+# todo: tighten this
+resource "aws_vpc_security_group_egress_rule" "squid_proxy_out" {
+  security_group_id = aws_security_group.squid_proxy.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+}
+
+resource "aws_ecs_service" "squid_proxy" {
+  name            = "squid-proxy"
+  cluster         = var.ecs_cluster
+  task_definition = aws_ecs_task_definition.squid_proxy.arn
+  desired_count   = 1
+
+  network_configuration {
+    subnets = var.public_subnets
+
+    security_groups = [
+      aws_security_group.squid_proxy.id
+    ]
+
+    assign_public_ip = true
+  }
+
+  service_registries {
+    registry_arn   = aws_service_discovery_service.squid_proxy.arn
+    container_name = "sqiud"
+  }
+
+  capacity_provider_strategy {
+    base              = 1
+    capacity_provider = "FARGATE"
+    weight            = 100
+  }
+
+  enable_execute_command = true
+
+  propagate_tags = "TASK_DEFINITION"
+}
+
+resource "aws_service_discovery_service" "squid_proxy" {
+  name = "squid-proxy"
+
+  dns_config {
+    namespace_id = var.ecs_discovery_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  # health_check_config {
+  #   failure_threshold = 1
+  #   type              = "TCP"
+  # }
+}

--- a/proxy/squid.tf
+++ b/proxy/squid.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.14"
+    }
+  }
+
+  required_version = ">= 1.10.0"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/proxy/variables.tf
+++ b/proxy/variables.tf
@@ -1,0 +1,48 @@
+######################################################################
+# Squid proxy
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "public_subnets" {
+  type        = list(string)
+  description = "Subnet IDs"
+}
+
+variable "ecs_cluster" {
+  type        = string
+  description = "ECS Cluster name"
+}
+
+variable "ecs_discovery_id" {
+  type        = string
+  description = "ECS Cluster DNS Discovery ID"
+}
+
+variable "kms_key" {
+  type        = string
+  description = "KMS key ARN"
+}
+
+variable "squid_proxy_repository" {
+  type        = string
+  default     = "docker.io/manics/squid-filtering-proxy"
+  description = "Squid proxy container repository"
+}
+
+variable "squid_proxy_version" {
+  type        = string
+  default     = "dev-amd64"
+  description = "Squid proxy container version"
+}
+
+variable "squid_proxy_allowed_domains" {
+  type = list(string)
+  default = [
+    "github.com",
+    "ghcr.io",
+  ]
+  description = "Squid proxy allowed domains"
+}

--- a/services.tf
+++ b/services.tf
@@ -64,8 +64,8 @@ module "dnsresolver" {
 
   static-ttl = 3600
   static = [
-    # # ECS Aliases
-    # ["proxy", "CNAME", "squid-proxy.${var.dns_domain}"],
+    # ECS Aliases
+    ["proxy", "CNAME", "squid-proxy.${var.dns_domain}"],
   ]
 
   private-records = {
@@ -95,4 +95,24 @@ module "certificate" {
   subject_alternative_names = [var.dns_domain]
 
   request_acm_certificate = var.request_certificate == "acm" ? true : false
+}
+
+
+module "cluster" {
+  source           = "./ecs-cluster"
+  name             = "squid-proxy"
+  vpc_id           = module.vpc.vpc_id
+  vpc_r53_id       = module.vpc.vpc_id
+  subnets          = slice(module.vpc.public_subnets, 0, 2)
+  discovery_domain = "ecs.${var.dns_domain}"
+}
+
+module "squid" {
+  source      = "./proxy"
+  ecs_cluster = module.cluster.ecs_cluster
+  kms_key     = module.cluster.kms_arn
+
+  vpc_id           = module.vpc.vpc_id
+  public_subnets   = slice(module.vpc.public_subnets, 0, 2)
+  ecs_discovery_id = module.cluster.discovery_id
 }

--- a/services.tf
+++ b/services.tf
@@ -101,9 +101,7 @@ module "certificate" {
 module "cluster" {
   source           = "./ecs-cluster"
   name             = "squid-proxy"
-  vpc_id           = module.vpc.vpc_id
   vpc_r53_id       = module.vpc.vpc_id
-  subnets          = slice(module.vpc.public_subnets, 0, 2)
   discovery_domain = "ecs.${var.dns_domain}"
 }
 


### PR DESCRIPTION
Do not merge, this is a reminder that we may want this to proxy and scan outgoing traffic. E.g. In HIC we make limited external package repositories available through this, with a virus scanner.