### PR TITLE
Explicitly define KMS key for storage encryption

### DIFF
--- a/efs/main.tf
+++ b/efs/main.tf
@@ -32,6 +32,7 @@ resource "aws_security_group" "efs_sg" {
 resource "aws_efs_file_system" "efs" {
   creation_token = var.name
   encrypted      = true
+  kms_key_id     = var.kms_key_arn
 
   tags = {
     Name = var.name
@@ -47,34 +48,3 @@ resource "aws_efs_mount_target" "mount" {
   security_groups = [aws_security_group.efs_sg.id]
 }
 
-
-
-# data "aws_caller_identity" "current" {}
-# data "aws_region" "current" {}
-
-# resource "aws_kms_key" "efs" {
-#   description             = "${var.name} KMS Key"
-#   deletion_window_in_days = 30
-#   enable_key_rotation     = true
-
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Id      = "EFS"
-#     Statement = [
-#       {
-#         Sid    = "Enable IAM User Permissions"
-#         Effect = "Allow"
-#         Principal = {
-#           AWS = format("arn:aws:iam::%s:root", data.aws_caller_identity.current.account_id)
-#         }
-#         Action   = "kms:*"
-#         Resource = "*"
-#       }
-#     ]
-#   })
-# }
-
-# resource "aws_kms_alias" "efs" {
-#   name          = "alias/${var.name}/efs"
-#   target_key_id = aws_kms_key.efs.key_id
-# }

--- a/efs/variables.tf
+++ b/efs/variables.tf
@@ -12,3 +12,9 @@ variable "subnets" {
   type        = list(string)
   description = "List of subnet IDs"
 }
+
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS encryption key ARN"
+  default     = null
+}

--- a/services.tf
+++ b/services.tf
@@ -1,3 +1,34 @@
+######################################################################
+# Storage encryption key
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "default-storage" {
+  description             = "${var.name} default storage key"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Root IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = format("arn:aws:iam::%s:root", data.aws_caller_identity.current.account_id)
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "default-storage" {
+  name          = "alias/${var.name}/default-storage"
+  target_key_id = aws_kms_key.default-storage.key_id
+}
+
 
 ######################################################################
 # EFS
@@ -7,10 +38,11 @@ locals {
 }
 
 module "efs" {
-  source  = "./efs"
-  name    = local.efs_token
-  vpc_id  = module.vpc.vpc_id
-  subnets = module.vpc.private_subnets
+  source      = "./efs"
+  name        = local.efs_token
+  vpc_id      = module.vpc.vpc_id
+  subnets     = module.vpc.private_subnets
+  kms_key_arn = aws_kms_key.default-storage.arn
 }
 
 


### PR DESCRIPTION
Define the key, instead of rely on the automatic default one that AWS creates.